### PR TITLE
Fix javadoc parse exception docs and encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,6 +151,12 @@ subprojects { subproject ->
         options.encoding = 'UTF-8'
     }
 
+    tasks.withType(Javadoc).configureEach {
+        options.encoding = 'UTF-8'
+        options.charSet = 'UTF-8'
+        options.docEncoding = 'UTF-8'
+    }
+
     tasks.withType(Test).configureEach {
         useJUnitPlatform()
         testLogging {

--- a/core/date/src/main/java/io/geewit/utils/core/date/DateUtils.java
+++ b/core/date/src/main/java/io/geewit/utils/core/date/DateUtils.java
@@ -24,6 +24,7 @@ public class DateUtils {
      * 字符串转换为日期
      * @param date 日期字符串
      * @return 日期
+     * @throws ParseException 日期解析异常
      */
     public static Date date(String date) throws ParseException {
         return org.apache.commons.lang3.time.DateUtils.parseDateStrictly(date, PATTERNS);


### PR DESCRIPTION
## Summary
- add missing Javadoc @throws documentation for ParseException
- enforce UTF-8 encoding for Javadoc generation to prevent garbled characters

## Testing
- ./gradlew :core:date:javadoc (fails: Gradle wrapper main class missing in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69326384aa80832392a09aac4bec85aa)