### PR TITLE
Update Jackson 3 imports and fix javadoc warnings

### DIFF
--- a/core/codec/src/main/java/io/geewit/utils/core/codec/CryptUtils.java
+++ b/core/codec/src/main/java/io/geewit/utils/core/codec/CryptUtils.java
@@ -25,6 +25,10 @@ public class CryptUtils {
     private final static String ALGORITHM = "AES";
     private final static String KEY = "key";
 
+    private CryptUtils() {
+        // utility class
+    }
+
     /**
      * 加密
      * @param value  未加密的字符串

--- a/core/enums/src/main/java/io/geewit/utils/core/enums/BinaryUtils.java
+++ b/core/enums/src/main/java/io/geewit/utils/core/enums/BinaryUtils.java
@@ -18,6 +18,7 @@ public class BinaryUtils {
      * 枚举转二进制
      *
      * @param enumType 枚举类型
+     * @param <E>      枚举
      * @return 二进制
      */
     public static <E extends Enum<E>> int toBinary(E enumType) {
@@ -28,6 +29,7 @@ public class BinaryUtils {
      * 转二进制掩码
      *
      * @param enumTypes 枚举类型
+     * @param <E>       枚举
      * @return 枚举
      */
     @SafeVarargs
@@ -57,6 +59,7 @@ public class BinaryUtils {
      *
      * @param binary 二进制掩码
      * @param clazz  枚举类型
+     * @param <E>    枚举
      * @return 枚举集合
      */
     public static <E extends Enum<E>> EnumSet<E> fromBinary(int binary, Class<E> clazz) {
@@ -68,6 +71,7 @@ public class BinaryUtils {
      *
      * @param binary 二进制掩码
      * @param clazz  枚举类型
+     * @param <E>    枚举
      * @return Integer集合
      */
     public static <E extends Enum<E>> List<Integer> fromBinaryToValues(int binary, Class<E> clazz) {
@@ -111,6 +115,14 @@ public class BinaryUtils {
         return EnumSet.allOf(clazz).stream().anyMatch(enu -> (1 << enu.ordinal() & value) > 0);
     }
 
+    /**
+     * 检查二进制参数的枚举开关集合是否有任意开启
+     *
+     * @param enumSet 枚举集合
+     * @param value   二进制参数
+     * @param <E>     枚举
+     * @return true:任意开
+     */
     public static <E extends Enum<E>> boolean hasAny(Collection<E> enumSet, int value) {
         if (null != enumSet) {
             return enumSet.stream().anyMatch(enu -> (1 << enu.ordinal() & value) > 0);

--- a/core/enums/src/main/java/io/geewit/utils/core/enums/EnumUtils.java
+++ b/core/enums/src/main/java/io/geewit/utils/core/enums/EnumUtils.java
@@ -53,6 +53,7 @@ public class EnumUtils {
      * @param clazz 枚举类 class
      * @param value Number 类型的参数
      * @param <E>   枚举
+     * @param <N>   数字类型
      * @return      枚举
      */
     public static <E extends Enum<E> & Value<N>, N extends Number> E forValue(Class<E> clazz, N value) {
@@ -71,6 +72,7 @@ public class EnumUtils {
      * @param value Number 类型的参数
      * @param defaultEnum 默认枚举值
      * @param <E>   枚举
+     * @param <N>   数字类型
      * @return      枚举
      */
     public static <E extends Enum<E> & Value<N>, N extends Number> E forValue(Class<E> clazz, N value, E defaultEnum) {

--- a/core/enums/src/main/java/io/geewit/utils/core/enums/Value.java
+++ b/core/enums/src/main/java/io/geewit/utils/core/enums/Value.java
@@ -2,8 +2,9 @@ package io.geewit.utils.core.enums;
 
 /**
  * 枚举可以实现该接口
+ *
  * @author geewit
- * @param <V> Number 类型
+ * @param <V> 数字类型
  */
 @SuppressWarnings({"unused"})
 public interface Value<V extends Number> {

--- a/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/deserializer/EnumNameDeserializer.java
+++ b/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/deserializer/EnumNameDeserializer.java
@@ -1,8 +1,8 @@
 package io.geewit.utils.core.jackson.databind.deserializer;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonDeserializer;
 import io.geewit.utils.core.enums.EnumUtils;
 import io.geewit.utils.core.enums.Name;
 

--- a/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/deserializer/EnumValueDeserializer.java
+++ b/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/deserializer/EnumValueDeserializer.java
@@ -1,8 +1,8 @@
 package io.geewit.utils.core.jackson.databind.deserializer;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonDeserializer;
 import io.geewit.utils.core.enums.EnumUtils;
 import io.geewit.utils.core.enums.Value;
 

--- a/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/serializer/BigDecimalSerializer.java
+++ b/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/serializer/BigDecimalSerializer.java
@@ -1,8 +1,8 @@
 package io.geewit.utils.core.jackson.databind.serializer;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JsonSerializer;
+import tools.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
 import java.math.BigDecimal;

--- a/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/serializer/EnumNameSerializer.java
+++ b/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/serializer/EnumNameSerializer.java
@@ -1,8 +1,8 @@
 package io.geewit.utils.core.jackson.databind.serializer;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JsonSerializer;
+import tools.jackson.databind.SerializerProvider;
 import io.geewit.utils.core.enums.Name;
 
 import java.io.IOException;

--- a/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/serializer/EnumValueSerializer.java
+++ b/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/serializer/EnumValueSerializer.java
@@ -1,8 +1,8 @@
 package io.geewit.utils.core.jackson.databind.serializer;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JsonSerializer;
+import tools.jackson.databind.SerializerProvider;
 import io.geewit.utils.core.enums.Value;
 
 import java.io.IOException;

--- a/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/serializer/JsonPageSerializer.java
+++ b/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/serializer/JsonPageSerializer.java
@@ -1,10 +1,10 @@
 package io.geewit.utils.core.jackson.databind.serializer;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JsonSerializer;
+import tools.jackson.databind.MapperFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializerProvider;
 import org.springframework.data.domain.Page;
 
 import java.io.IOException;

--- a/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/serializer/LongSerializer.java
+++ b/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/serializer/LongSerializer.java
@@ -1,8 +1,8 @@
 package io.geewit.utils.core.jackson.databind.serializer;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializerProvider;
+import tools.jackson.databind.ser.std.StdSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/serializer/MoneySerializer.java
+++ b/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/serializer/MoneySerializer.java
@@ -1,8 +1,8 @@
 package io.geewit.utils.core.jackson.databind.serializer;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JsonSerializer;
+import tools.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
 import java.math.BigDecimal;

--- a/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/serializer/PasswordSerializer.java
+++ b/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/serializer/PasswordSerializer.java
@@ -1,8 +1,8 @@
 package io.geewit.utils.core.jackson.databind.serializer;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JsonSerializer;
+import tools.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
 

--- a/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/serializer/RadioSerializer.java
+++ b/core/jackson/src/main/java/io/geewit/utils/core/jackson/databind/serializer/RadioSerializer.java
@@ -1,8 +1,8 @@
 package io.geewit.utils.core.jackson.databind.serializer;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JsonSerializer;
+import tools.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
 import java.math.BigDecimal;

--- a/core/jackson/src/main/java/io/geewit/utils/core/jackson/view/View.java
+++ b/core/jackson/src/main/java/io/geewit/utils/core/jackson/view/View.java
@@ -1,7 +1,7 @@
 package io.geewit.utils.core.jackson.view;
 
 /**
- * @see com.fasterxml.jackson.annotation.JsonView
+ * @see tools.jackson.annotation.JsonView
  * @author geewit
  */
 @SuppressWarnings({"unused"})


### PR DESCRIPTION
## Summary
- update Jackson serializers/deserializers and JsonView reference to the new `tools.jackson` package after the v3 upgrade
- tighten enum utility Javadocs and add missing type parameter documentation to clear doclint warnings
- add an explicit private constructor to the codec utility class to avoid undocumented default constructor warnings

## Testing
- `gradle :core:jackson:compileJava` *(fails: dependency download blocked with HTTP 403 while resolving org.slf4j:slf4j-api:2.0.17)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932b0a1ccec83238533c8e96751a89b)