### PR TITLE
Add JPMS module descriptors

### DIFF
--- a/core/codec/src/main/java/module-info.java
+++ b/core/codec/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module io.geewit.utils.core.codec {
+    requires transitive commons.codec;
+    requires transitive org.slf4j;
+
+    exports io.geewit.utils.core.codec;
+}

--- a/core/date/src/main/java/module-info.java
+++ b/core/date/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module io.geewit.utils.core.date {
+    requires transitive org.apache.commons.lang3;
+    requires transitive org.slf4j;
+
+    exports io.geewit.utils.core.date;
+}

--- a/core/enums/src/main/java/module-info.java
+++ b/core/enums/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module io.geewit.utils.core.enums {
+    requires transitive org.slf4j;
+
+    exports io.geewit.utils.core.enums;
+}

--- a/core/jackson/src/main/java/module-info.java
+++ b/core/jackson/src/main/java/module-info.java
@@ -1,0 +1,22 @@
+module io.geewit.utils.core.jackson {
+    requires transitive io.geewit.utils.core.enums;
+    requires transitive com.fasterxml.jackson.annotation;
+    requires transitive com.fasterxml.jackson.core;
+    requires transitive com.fasterxml.jackson.databind;
+    requires transitive org.slf4j;
+    requires transitive spring.boot;
+    requires transitive spring.boot.autoconfigure;
+    requires transitive spring.context;
+    requires transitive spring.core;
+    requires transitive spring.beans;
+    requires transitive spring.data.commons;
+
+    exports io.geewit.utils.core.jackson.config;
+    exports io.geewit.utils.core.jackson.databind.deserializer;
+    exports io.geewit.utils.core.jackson.databind.serializer;
+    exports io.geewit.utils.core.jackson.view;
+
+    opens io.geewit.utils.core.jackson.config to spring.core, spring.beans, spring.context, spring.boot.autoconfigure;
+    opens io.geewit.utils.core.jackson.databind.deserializer to spring.core, spring.beans, spring.context;
+    opens io.geewit.utils.core.jackson.databind.serializer to spring.core, spring.beans, spring.context;
+}

--- a/core/lang/src/main/java/module-info.java
+++ b/core/lang/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module io.geewit.utils.core.lang {
+    requires transitive org.apache.commons.lang3;
+    requires transitive org.slf4j;
+
+    exports io.geewit.utils.core.lang;
+}

--- a/core/reflection/src/main/java/module-info.java
+++ b/core/reflection/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module io.geewit.utils.core.reflection {
+    requires transitive org.apache.commons.lang3;
+    requires transitive org.slf4j;
+    requires transitive spring.beans;
+    requires transitive spring.core;
+
+    exports io.geewit.utils.core.reflection;
+}

--- a/core/tree/src/main/java/module-info.java
+++ b/core/tree/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module io.geewit.utils.core.tree {
+    requires transitive org.apache.commons.lang3;
+    requires transitive org.slf4j;
+    requires static lombok;
+
+    exports io.geewit.utils.core.tree;
+}

--- a/core/uuid/src/main/java/module-info.java
+++ b/core/uuid/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module io.geewit.utils.core.uuid {
+    requires transitive commons.codec;
+    requires transitive org.slf4j;
+
+    exports io.geewit.utils.core.uuid;
+}

--- a/data/commons/src/main/java/module-info.java
+++ b/data/commons/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module io.geewit.utils.data.commons {
+    requires transitive io.geewit.utils.core.enums;
+
+    exports io.geewit.utils.data.commons;
+}

--- a/data/spring/src/main/java/module-info.java
+++ b/data/spring/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module io.geewit.utils.data.spring {
+    requires transitive org.slf4j;
+    requires transitive spring.data.commons;
+    requires static org.jspecify;
+
+    exports io.geewit.utils.data.spring;
+}

--- a/web/converter/src/main/java/module-info.java
+++ b/web/converter/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module io.geewit.utils.web.converter {
+    requires transitive io.geewit.utils.core.enums;
+    requires transitive org.apache.commons.lang3;
+    requires transitive org.slf4j;
+    requires transitive spring.core;
+    requires transitive spring.context;
+
+    exports io.geewit.utils.web.converter;
+}

--- a/web/core/src/main/java/module-info.java
+++ b/web/core/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module io.geewit.utils.web.core {
+    requires transitive org.slf4j;
+    requires transitive spring.context;
+    requires transitive spring.beans;
+
+    exports io.geewit.utils.web.core;
+
+    opens io.geewit.utils.web.core to spring.core, spring.beans, spring.context;
+}

--- a/web/json/src/main/java/module-info.java
+++ b/web/json/src/main/java/module-info.java
@@ -1,0 +1,10 @@
+module io.geewit.utils.web.json {
+    requires transitive io.geewit.utils.web.core;
+    requires transitive com.fasterxml.jackson.annotation;
+    requires transitive com.fasterxml.jackson.core;
+    requires transitive com.fasterxml.jackson.databind;
+    requires transitive org.slf4j;
+    requires transitive spring.web;
+
+    exports io.geewit.utils.web.json;
+}


### PR DESCRIPTION
## Summary
- add JPMS module descriptors for the core utility subprojects with explicit exports and dependencies
- define module metadata for the data and web modules, including Spring openings where reflection is needed

## Testing
- Not run (gradle wrapper not present in repository)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932d8cf62f483238d24531f4b6964fb)