### PR TITLE
Add builder and initialize method to PagedCrudTableControl

### DIFF
--- a/javafx/controls/src/main/java/io/geewit/utils/javafx/control/paged/PagedCrudTableControl.java
+++ b/javafx/controls/src/main/java/io/geewit/utils/javafx/control/paged/PagedCrudTableControl.java
@@ -34,6 +34,40 @@ public final class PagedCrudTableControl<T, K, Q> extends Control {
         super.getStyleClass().add("paged-crud-table");
     }
 
+    // ===== Builder =====
+    public static <T, K, Q> Builder<T, K, Q> builder() {
+        return new Builder<>();
+    }
+
+    public static final class Builder<T, K, Q> {
+        private List<TableColumn<T, ?>> columns;
+        private PagedCrudTableConfig<T, K, Q> config;
+
+        private Builder() {}
+
+        public Builder<T, K, Q> columns(List<TableColumn<T, ?>> columns) {
+            this.columns = columns;
+            return this;
+        }
+
+        public Builder<T, K, Q> config(PagedCrudTableConfig<T, K, Q> config) {
+            this.config = config;
+            return this;
+        }
+
+        public PagedCrudTableControl<T, K, Q> build() {
+            return new PagedCrudTableControl<T, K, Q>()
+                    .initialize(columns, config);
+        }
+    }
+
+    public PagedCrudTableControl<T, K, Q> initialize(List<TableColumn<T, ?>> columns,
+                                                     PagedCrudTableConfig<T, K, Q> config) {
+        setColumns(columns);
+        setConfig(Objects.requireNonNull(config, "config must not be null"));
+        return this;
+    }
+
     /**
      * 创建默认的皮肤对象
      *


### PR DESCRIPTION
### Motivation

- Provide a fluent builder API to simplify construction and configuration of `PagedCrudTableControl` instances.
- Allow callers to set `columns` and the required `config` in a single step and support method chaining.

### Description

- Add a static `builder()` factory and an inner `Builder<T,K,Q>` class with `columns(...)`, `config(...)`, and `build()` methods.
- Implement `initialize(List<TableColumn<T, ?>>, PagedCrudTableConfig<T,K,Q>)` on `PagedCrudTableControl` to apply `columns` and a non-null `config` and return the control for chaining.
- The `Builder.build()` now constructs a `PagedCrudTableControl` and calls `initialize(...)` to apply the provided values.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a0a70e7ec8323892495e464b80a56)